### PR TITLE
to manage tables with multiple schema in the database

### DIFF
--- a/schema_engine.py
+++ b/schema_engine.py
@@ -17,7 +17,27 @@ class SchemaEngine(SQLDatabase):
                          indexes_in_table_info, custom_table_info, view_support, max_string_length)
 
         self._db_name = db_name
-        self._usable_tables = [table_name for table_name in self._usable_tables if self._inspector.has_table(table_name, schema)]
+        # Dictionary to store table names and their corresponding schema
+        self._tables_schemas: Dict[str, str] = {}
+
+        # If a schema is specified, filter by that schema and store that value for every table.
+        if schema:
+            self._usable_tables = [
+                table_name for table_name in self._usable_tables
+                if self._inspector.has_table(table_name, schema)
+            ]
+            for table_name in self._usable_tables:
+                self._tables_schemas[table_name] = schema
+        else:
+            all_tables = []
+            # Iterate through all available schemas
+            for s in self.get_schema_names():
+                tables = self._inspector.get_table_names(schema=s)
+                all_tables.extend(tables)
+                for table in tables:
+                    self._tables_schemas[table] = s
+            self._usable_tables = all_tables
+
         self._dialect = engine.dialect.name
         if mschema is not None:
             self._mschema = mschema
@@ -31,12 +51,12 @@ class SchemaEngine(SQLDatabase):
         return self._mschema
 
     def get_pk_constraint(self, table_name: str) -> Dict:
-        return self._inspector.get_pk_constraint(table_name, self._schema)['constrained_columns']
+        return self._inspector.get_pk_constraint(table_name, self._tables_schemas[table_name] )['constrained_columns']
 
     def get_table_comment(self, table_name: str):
         try:
-            return self._inspector.get_table_comment(table_name, self._schema)['text']
-        except:    # sqlite不支持添加注释
+            return self._inspector.get_table_comment(table_name, self._tables_schemas[table_name])['text']
+        except:    # sqlite does not support comments
             return ''
 
     def default_schema_name(self) -> Optional[str]:
@@ -46,14 +66,14 @@ class SchemaEngine(SQLDatabase):
         return self._inspector.get_schema_names()
 
     def get_foreign_keys(self, table_name: str):
-        return self._inspector.get_foreign_keys(table_name, self._schema)
+        return self._inspector.get_foreign_keys(table_name, self._tables_schemas[table_name])
 
     def get_unique_constraints(self, table_name: str):
-        return self._inspector.get_unique_constraints(table_name, self._schema)
+        return self._inspector.get_unique_constraints(table_name, self._tables_schemas[table_name])
 
     def fectch_distinct_values(self, table_name: str, column_name: str, max_num: int = 5):
-        table = Table(table_name, self.metadata_obj, autoload_with=self._engine)
-        # 构建 SELECT DISTINCT 查询
+        table = Table(table_name, self.metadata_obj, autoload_with=self._engine, schema=self._tables_schemas[table_name])
+        # Construct SELECT DISTINCT query
         query = select(table.c[column_name]).distinct().limit(max_num)
         values = []
         with self._engine.connect() as connection:
@@ -68,24 +88,21 @@ class SchemaEngine(SQLDatabase):
         for table_name in self._usable_tables:
             table_comment = self.get_table_comment(table_name)
             table_comment = '' if table_comment is None else table_comment.strip()
-            self._mschema.add_table(table_name, fields={}, comment=table_comment)
+            table_with_schema = self._tables_schemas[table_name] + '.' + table_name
+            self._mschema.add_table(table_with_schema, fields={}, comment=table_comment)
             pks = self.get_pk_constraint(table_name)
 
             fks = self.get_foreign_keys(table_name)
             for fk in fks:
                 referred_schema = fk['referred_schema']
                 for c, r in zip(fk['constrained_columns'], fk['referred_columns']):
-                    self._mschema.add_foreign_key(table_name, c, referred_schema, fk['referred_table'], r)
+                    self._mschema.add_foreign_key(table_with_schema, c, referred_schema, fk['referred_table'], r)
 
-            fields = self._inspector.get_columns(table_name, schema=self._schema)
+            fields = self._inspector.get_columns(table_name, schema=self._tables_schemas[table_name])
             for field in fields:
                 field_type = f"{field['type']!s}"
                 field_name = field['name']
-                if field_name in pks:
-                    primary_key = True
-                else:
-                    primary_key = False
-
+                primary_key = field_name in pks
                 field_comment = field.get("comment", None)
                 field_comment = "" if field_comment is None else field_comment.strip()
                 autoincrement = field.get('autoincrement', False)
@@ -99,6 +116,8 @@ class SchemaEngine(SQLDatabase):
                     examples = []
                 examples = examples_to_str(examples)
 
-                self._mschema.add_field(table_name, field_name, field_type=field_type, primary_key=primary_key,
+                self._mschema.add_field(
+                    table_with_schema, field_name, field_type=field_type, primary_key=primary_key,
                     nullable=field['nullable'], default=default, autoincrement=autoincrement,
-                    comment=field_comment, examples=examples)
+                    comment=field_comment, examples=examples
+                )


### PR DESCRIPTION
It's not managed now the tables with multiple schema in the database. Only the ones with default schema ( e.g. "dbo" ) are then in the mschema